### PR TITLE
Full PNPM support

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -144,4 +144,5 @@ runs:
 
     - name: Install dependencies
       if: inputs.NODE_PACKAGE_MANAGER == 'pnpm'
+      shell: bash
       run: pnpm install

--- a/action.yaml
+++ b/action.yaml
@@ -64,8 +64,6 @@ runs:
     - name: Install pnpm
       if: inputs.NODE_PACKAGE_MANAGER == 'pnpm'
       uses: pnpm/action-setup@v3
-      with:
-        version: 8
     
     - name: Setup Nodejs
       uses: actions/setup-node@v4
@@ -73,32 +71,12 @@ runs:
       with:
         node-version: ${{ inputs.NODE_VERSION }}
         cache: ${{ inputs.NODE_PACKAGE_MANAGER }}
-        # Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. 
-        # It will generate hash from the target file for primary key. It works only If cache is specified.  
-        # Supports wildcards or a list of file names for caching multiple dependencies.
-        # Default: ''
-        # cache-dependency-path: '**/package-lock.json'
+
     - name: Setup Nodejs Without Cache
       uses: actions/setup-node@v4
       if: inputs.DISABLE_NPM_CACHE == 'true'
       with:
         node-version: ${{ inputs.NODE_VERSION }}
-
-    # Begin Backward compatible setup
-    - name: Setup PNPM
-      uses: pnpm/action-setup@v2
-      if: inputs.DISABLE_NPM_CACHE == 'pnpm'
-      with:
-        version: 8.14.3
-
-    - name: Setup Nodejs Using PNPM
-      uses: actions/setup-node@v4
-      if: inputs.DISABLE_NPM_CACHE == 'pnpm'
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache: 'pnpm'
-        cache-dependency-path: '**/pnpm-lock.yaml'
-    # End Backward compatible setip
 
     - name: Configure NPM registry for Bison
       run: |
@@ -141,8 +119,3 @@ runs:
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
-
-    - name: Install dependencies
-      if: inputs.NODE_PACKAGE_MANAGER == 'pnpm'
-      shell: bash
-      run: pnpm install

--- a/action.yaml
+++ b/action.yaml
@@ -64,8 +64,8 @@ runs:
     - name: Install pnpm
       if: inputs.NODE_PACKAGE_MANAGER == 'pnpm'
       uses: pnpm/action-setup@v3
-        with:
-          version: 8
+      with:
+        version: 8
     
     - name: Setup Nodejs
       uses: actions/setup-node@v4

--- a/action.yaml
+++ b/action.yaml
@@ -133,7 +133,7 @@ runs:
       run: |
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: inputs.NODE_PACKAGE_MANAGER == 'pnpm'
       name: Setup pnpm cache
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -35,12 +35,17 @@ inputs:
     description: SHEETJS_TOKEN
     required: false
     default: ""
+  NODE_PACKAGE_MANAGER:
+    description: "Node package manager npm, yarn, or pnpm"
+    required: false
+    default: "npm"
 runs:
   using: composite
   steps:
     - name: Debug
       run: echo "${{ github.repository }}/${{ github.ref_name }}"
       shell: bash
+
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -49,28 +54,43 @@ runs:
         fetch-depth: ${{ inputs.REPO_DEPTH }}
         ref: ${{ inputs.VERSION_TAG }}
         repository: ${{ inputs.REPOSITORY }}
+    
     - name: Git Config
       run: |
         git config --global user.name "GitHub Actions"
         git config --global user.email "actions@users.noreply.github.com"
       shell: bash
+
+    - name: Install pnpm
+      if: inputs.NODE_PACKAGE_MANAGER == 'pnpm'
+      uses: pnpm/action-setup@v3
+        with:
+          version: 8
+    
     - name: Setup Nodejs
       uses: actions/setup-node@v4
       if: inputs.DISABLE_NPM_CACHE == 'false'
       with:
         node-version: ${{ inputs.NODE_VERSION }}
-        cache: 'npm'
-        cache-dependency-path: '**/package-lock.json'
+        cache: ${{ inputs.NODE_PACKAGE_MANAGER }}
+        # Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. 
+        # It will generate hash from the target file for primary key. It works only If cache is specified.  
+        # Supports wildcards or a list of file names for caching multiple dependencies.
+        # Default: ''
+        # cache-dependency-path: '**/package-lock.json'
     - name: Setup Nodejs Without Cache
       uses: actions/setup-node@v4
       if: inputs.DISABLE_NPM_CACHE == 'true'
       with:
         node-version: ${{ inputs.NODE_VERSION }}
+
+    # Begin Backward compatible setup
     - name: Setup PNPM
       uses: pnpm/action-setup@v2
       if: inputs.DISABLE_NPM_CACHE == 'pnpm'
       with:
         version: 8.14.3
+
     - name: Setup Nodejs Using PNPM
       uses: actions/setup-node@v4
       if: inputs.DISABLE_NPM_CACHE == 'pnpm'
@@ -78,6 +98,8 @@ runs:
         node-version: ${{ inputs.NODE_VERSION }}
         cache: 'pnpm'
         cache-dependency-path: '**/pnpm-lock.yaml'
+    # End Backward compatible setip
+
     - name: Configure NPM registry for Bison
       run: |
         npm config set '@circle9r:registry' 'https://npm.pkg.github.com/'
@@ -104,3 +126,22 @@ runs:
       with:
         mask-password: 'true'
         registries: ${{ inputs.AWS_REGISTRY }}
+
+    - name: Get pnpm store directory
+      if: inputs.NODE_PACKAGE_MANAGER == 'pnpm'
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - uses: actions/cache@v3
+      if: inputs.NODE_PACKAGE_MANAGER == 'pnpm'
+      name: Setup pnpm cache
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      if: inputs.NODE_PACKAGE_MANAGER == 'pnpm'
+      run: pnpm install


### PR DESCRIPTION
Rather than use a slightly ambiguous input I made an explicit one on what package manager to use. All the three major package managers are directly supported in the other action(s) we're using. I also added in full pnpm caching based on pnpm's own action documentation, https://github.com/pnpm/action-setup.

The node caching never required an explicit cache-dependency-path as it handles it internally, https://github.com/actions/setup-node/blob/main/src/cache-utils.ts#L20-L67

An example of all of this: https://github.com/circle9r/bison-design-system/actions/runs/8101966241/job/22143398607 